### PR TITLE
FIX typo coditional -> conditional

### DIFF
--- a/ConfigSpace/configuration_space.py
+++ b/ConfigSpace/configuration_space.py
@@ -407,7 +407,7 @@ class ConfigurationSpace(object):
                       if parent_name != "__HPOlib_configuration_space_root__"]
         return conditions
 
-    def get_all_uncoditional_hyperparameters(self):
+    def get_all_unconditional_hyperparameters(self):
         hyperparameters = [hp_name for hp_name in
                            self._children[
                                '__HPOlib_configuration_space_root__']]
@@ -576,7 +576,7 @@ class ConfigurationSpace(object):
             for i in range(missing):
                 inactive = set()
                 visited = set()
-                visited.update(self.get_all_uncoditional_hyperparameters())
+                visited.update(self.get_all_unconditional_hyperparameters())
                 to_visit = deque()
                 to_visit.extendleft(self.get_all_conditional_hyperparameters())
                 infiniteloopcounter = 0

--- a/test/test_configuration_space.py
+++ b/test/test_configuration_space.py
@@ -117,7 +117,7 @@ class TestConfigurationSpace(unittest.TestCase):
         cs.add_hyperparameter(hp4)
 
         cs.add_condition(andconj1)
-        self.assertNotIn(hp4, cs.get_all_uncoditional_hyperparameters())
+        self.assertNotIn(hp4, cs.get_all_unconditional_hyperparameters())
 
     def test_add_second_condition_wo_conjunction(self):
         hp1 = CategoricalHyperparameter("input1", [0, 1])


### PR DESCRIPTION
There was a typo that I noticed when writing a converter from our new configuration utility for sacred to ConfigSpace.
This fixes it, I think it should neither affect smac3 or RoBO.
